### PR TITLE
Switch to git diff --exit-code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check git status
         run: git status --porcelain=v1
       - name: Ensure no staged changes
-        run: test $(git status --porcelain=v1 2>/dev/null | wc -l) -eq 0
+        run: git diff --exit-code
 
       # Docs are hosted on Netlify but we should get feedback on that here in Actions as well
       - name: Build docs


### PR DESCRIPTION
Provides a more elegant way to check up-to-date-ness