### PR TITLE
Fix downstream PR update workflow

### DIFF
--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -22,6 +22,9 @@ jobs:
       REF_URL: https://github.com/${{ github.repository }}/tree/${{ github.sha }}
       GIT_USER: ${{ github.actor }}
       GIT_EMAIL: ${{ github.actor }}@users.noreply.github.com
+      GIT_BRANCH: detsys-ts-update-${{ github.sha }}
+      GIT_BASE: main
+      GIT_HEAD: ${{ github.actor }}:detsys-ts-update-${{ github.sha }}
       TARGET_REPO: ${{ github.repository_owner }}/${{ matrix.repo }}
       SOURCE_REPO: ${{ github.repository }}
       GITHUB_TOKEN: ${{ github.token }}
@@ -50,6 +53,8 @@ jobs:
 
       - name: Commit changes to package.json, pnpm-lock.yaml, and dist/
         run: |
+          git checkout -b ${{ env.GIT_BRANCH }}
+
           git add .
 
           if [[ $(git status -s) ]]; then
@@ -66,6 +71,8 @@ jobs:
       - name: Create pull request against ${{ env.TARGET_REPO }}
         run: |
           gh pr create \
+            --base ${{ env.GIT_BASE }} \
+            --head ${{ env.GIT_HEAD }} \
             --repo ${{ env.TARGET_REPO }} \
             --title "Update detsys-ts dependency and dist directory (trigged by ${{ env.SOURCE_REPO }})" \
             --body "Bump detsys-ts to [${{ env.REF }}](${{ env.REF_URL }}) and regenerate application bundle."


### PR DESCRIPTION
- Enable specifying the separation character
- Update code comment
- Provide testing
- Add test
- Update test suite
- Fixup: saving to the cache ins't a hit
- Add facts for the eventual source URL and etag for workflow success monitoring
- rebaes, fixup
- Staple a compressed and b64'd log file in error conditions
- regen
- Make getTemporaryName public
- gzip not deflate oops
- Record stapler errors seperately
- Update src/index.ts
- regen
- ?
- Handle empty inputs better on arrays
- rebuild
- stop looking for nix when you've found it
- Support preflighting the store trust, for magic nix cache
- Make the preflight silent
- Don't double-init nixStoreTrust
- Don't double-init nixStoreTrust
- Separate noisilyGetInput function from usage
- Add shadowing lint
- More documentation for enums
- More docs
- Regenerate dist
- Make core Action class abstract
- Fix test-run.ts
- Add helper function for unpacking closures
- Add more docs and helpers
- Fix test-run script
- Change name of strict mode param
- Add support for source-binary input
- Update docs
- Rearrange functions
- Make sure source-binary isn't an empty string
- Update doc strings
- Docs update to fetching logic
- Add getArrayOfStringsOrNull function
- Revert trivial changes to test
- Fix doc
- Provide error stringification function
- JSONify as last resort
- Add 30-second timeout for diagnostic endpoint POST
- Change timeout name
- Change var name
- Use SRV records as service discovery for IDS
- Only allow SRV records to resolve to certain prefixes
- Run eslint on the tests too, for error avoidance
- regen
- regen
- Fixup a couple missing awaits and check for them
- Break the ownership of getRootUrl
- Support - to mean default diagnostics
- Submit diagnostics to a second URL if it fails
- drop now unused mungeDiagnosticEndpoint
- Nits
- Add checkin behavior which preflights the IDS backend, and adds support for feature flags
- Try doing the for loop again but ... right ...
- ...iterable
- SIGH. Javascript. You can't deserialize json into a map.
- .
- Don't prefix feature_flag_called
- Auto-submit pull requests upon merge to main
- Don't run on pull request events
- Use ref URL in PR body
- Make env var name more specific
- Put GitHub token in env
- Specify base and head in gh pr create command

##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
