### PR TITLE
Remove FHC action since it's composite

### DIFF
--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -18,7 +18,6 @@ jobs:
         repo:
           - flake-checker-action
           - magic-nix-cache-action
-          - flakehub-cache-action
           - flakehub-push
           - flakehub-mirror
           - nix-installer-action


### PR DESCRIPTION
##### Description

We no longer need to push changes to `flakehub-cache-action`, since it's a composite action now.

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
