### PR TITLE
Provide pinning for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,5 +32,5 @@ updates:
         patterns: ["*"]
     labels:
       - dependencies
-      - github-actions
+      - npm
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,36 @@
 version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      actions-deps:
-        patterns:
-          - '*'
 
-  - package-ecosystem: "npm"
-    directory: "/"
+updates:
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+      - github-actions
+    ignore:
+      - dependency-name: DeterminateSystems/*
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       npm-deps:
-        patterns:
-          - '*'
+        patterns: ["*"]
+    labels:
+      - dependencies
+      - github-actions
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
       - uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Check Nix formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
+        with:
+          persist-credentials: false
+
+      - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Check Nix formatting

--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           path: current
           token: ${{ env.GH_TOKEN }}
+          persist-credentials: false
 
       - name: Get last detsys-ts commit message
         id: commit-msg
@@ -60,9 +61,10 @@ jobs:
           path: target
           repository: ${{ env.TARGET_REPO }}
           token: ${{ env.GH_TOKEN }}
+          persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
+        uses: DeterminateSystems/determinate-nix-action@main
 
       - name: Set up FlakeHub Cache
         uses: DeterminateSystems/flakehub-cache-action@main

--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -42,7 +42,7 @@ jobs:
       GH_TOKEN: ${{ secrets.detsys_pr_bot_token }} # for `gh pr create`
     steps:
       - name: Check out detsys-ts
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: current
           token: ${{ env.GH_TOKEN }}
@@ -55,14 +55,14 @@ jobs:
           echo "msg=${MSG}" >> $GITHUB_OUTPUT
 
       - name: Check out ${{ env.TARGET_REPO }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: target
           repository: ${{ env.TARGET_REPO }}
           token: ${{ env.GH_TOKEN }}
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3.20.0
 
       - name: Set up FlakeHub Cache
         uses: DeterminateSystems/flakehub-cache-action@main
@@ -97,7 +97,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         env:
           COMMIT_MSG: ${{ steps.commit-msg.outputs.msg }}
         with:

--- a/.github/workflows/update-downstream.yml
+++ b/.github/workflows/update-downstream.yml
@@ -71,9 +71,12 @@ jobs:
 
       - name: Configure Git for ${{ env.GIT_USER }}
         working-directory: target
+        env:
+          GIT_EMAIL: ${{ env.GIT_EMAIL }}
+          GIT_USER: ${{ env.GIT_USER }}
         run: |
-          git config user.name "${{ env.GIT_USER }}"
-          git config user.email "${{ env.GIT_EMAIL }}"
+          git config user.name "$GIT_USER"
+          git config user.email "$GIT_EMAIL"
 
       - name: Make sure the repo is forked
         working-directory: target

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          config: .github/zizmor.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        DeterminateSystems/*: ref-pin


### PR DESCRIPTION
This pins our GitHub Actions and provides automated updates. This PR also specifies cooldown for npm dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified and strengthened dependency update configuration: grouping, weekly cadence, cooldown, commit/label behavior, and semver-specific thresholds for npm updates.
  * Pinned CI and downstream workflow actions to specific commits to improve reproducibility and security.
  * Added repository policy rules to enforce ref-pinning for referenced actions.
  * Added a new automated workflow to run checks on pushes to main and on pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->